### PR TITLE
fix: scent checks force-loading chunks during entity unload

### DIFF
--- a/src/main/java/snownee/fruits/bee/network/CInspectTargetPacket.java
+++ b/src/main/java/snownee/fruits/bee/network/CInspectTargetPacket.java
@@ -18,6 +18,7 @@ import snownee.fruits.Hooks;
 import snownee.fruits.bee.BeeAttributes;
 import snownee.fruits.duck.FFPlayer;
 import snownee.fruits.gadget.ScentType;
+import snownee.fruits.util.CommonProxy;
 import snownee.kiwi.network.KiwiPacket;
 import snownee.kiwi.network.PacketHandler;
 
@@ -49,16 +50,18 @@ public class CInspectTargetPacket extends PacketHandler {
 					SInspectBeeReplyPacket.send(player, BeeAttributes.of(bee));
 				}
 			} else if (action == InspectAction.SCENT) {
-				LevelChunk chunk = level.getChunkAt(((InspectTarget.BlockTarget) target).pos());
+				LevelChunk chunk = CommonProxy.getLoadedChunkAt(level, ((InspectTarget.BlockTarget) target).pos());
 				long gameTime = level.getGameTime();
 				int count = 0;
 				long firstEnds = Long.MAX_VALUE;
-				for (ScentType type : FFRegistries.SCENT_TYPE) {
-					long time = type.getTime(chunk);
-					if (time > gameTime) {
-						count++;
-						if (time < firstEnds) {
-							firstEnds = time;
+				if (chunk != null) {
+					for (ScentType type : FFRegistries.SCENT_TYPE) {
+						long time = type.getTime(chunk);
+						if (time > gameTime) {
+							count++;
+							if (time < firstEnds) {
+								firstEnds = time;
+							}
 						}
 					}
 				}

--- a/src/main/java/snownee/fruits/mixin/scent/EndermanLeaveBlockGoalMixin.java
+++ b/src/main/java/snownee/fruits/mixin/scent/EndermanLeaveBlockGoalMixin.java
@@ -13,8 +13,10 @@ import net.minecraft.world.entity.monster.EnderMan;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.LevelChunk;
 import snownee.fruits.Hooks;
 import snownee.fruits.gadget.GadgetModule;
+import snownee.fruits.util.CommonProxy;
 
 @Mixin(EnderMan.EndermanTakeBlockGoal.class)
 public class EndermanLeaveBlockGoalMixin {
@@ -27,8 +29,11 @@ public class EndermanLeaveBlockGoalMixin {
 			Operation<Boolean> original,
 			@Local Level level,
 			@Local BlockPos pos) {
-		if (Hooks.gadget && GadgetModule.ENDER.get().isActiveAt(level.getChunkAt(pos))) {
-			return false;
+		if (Hooks.gadget) {
+			LevelChunk chunk = CommonProxy.getLoadedChunkAt(level, pos);
+			if (chunk != null && GadgetModule.ENDER.get().isActiveAt(chunk)) {
+				return false;
+			}
 		}
 		return original.call(blockState, tagKey);
 	}

--- a/src/main/java/snownee/fruits/mixin/scent/EndermanTakeBlockGoalMixin.java
+++ b/src/main/java/snownee/fruits/mixin/scent/EndermanTakeBlockGoalMixin.java
@@ -9,8 +9,10 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.monster.EnderMan;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.LevelChunk;
 import snownee.fruits.Hooks;
 import snownee.fruits.gadget.GadgetModule;
+import snownee.fruits.util.CommonProxy;
 
 @Mixin(EnderMan.EndermanLeaveBlockGoal.class)
 public class EndermanTakeBlockGoalMixin {
@@ -23,7 +25,11 @@ public class EndermanTakeBlockGoalMixin {
 			BlockState belowDestinationState,
 			BlockPos belowDestinationPos,
 			CallbackInfoReturnable<Boolean> cir) {
-		if (Hooks.gadget && GadgetModule.ENDER.get().isActiveAt(level.getChunkAt(destinationPos))) {
+		if (!Hooks.gadget) {
+			return;
+		}
+		LevelChunk chunk = CommonProxy.getLoadedChunkAt(level, destinationPos);
+		if (chunk != null && GadgetModule.ENDER.get().isActiveAt(chunk)) {
 			cir.setReturnValue(false);
 		}
 	}

--- a/src/main/java/snownee/fruits/mixin/scent/EntityMixin.java
+++ b/src/main/java/snownee/fruits/mixin/scent/EntityMixin.java
@@ -1,7 +1,5 @@
 package snownee.fruits.mixin.scent;
 
-import java.util.Objects;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -12,8 +10,10 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.chunk.LevelChunk;
 import snownee.fruits.Hooks;
 import snownee.fruits.gadget.GadgetModule;
+import snownee.fruits.util.CommonProxy;
 
 @Mixin(value = Entity.class, priority = 600)
 public abstract class EntityMixin {
@@ -26,8 +26,11 @@ public abstract class EntityMixin {
 	@Inject(method = "teleportTo(DDD)V", at = @At("HEAD"), cancellable = true)
 	private void teleportTo(double x, double y, double z, CallbackInfo ci) {
 		Entity entity = (Entity) (Object) this;
-		if (Hooks.gadget && entity instanceof LivingEntity && GadgetModule.ENDER.get().isActiveAt(Objects.requireNonNull(level())
-				.getChunkAt(blockPosition()))) {
+		if (!Hooks.gadget || !(entity instanceof LivingEntity)) {
+			return;
+		}
+		LevelChunk chunk = CommonProxy.getLoadedChunkAt(level(), blockPosition());
+		if (chunk != null && GadgetModule.ENDER.get().isActiveAt(chunk)) {
 			ci.cancel();
 		}
 	}

--- a/src/main/java/snownee/fruits/mixin/scent/LivingEntityMixin.java
+++ b/src/main/java/snownee/fruits/mixin/scent/LivingEntityMixin.java
@@ -1,7 +1,5 @@
 package snownee.fruits.mixin.scent;
 
-import java.util.Objects;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -23,6 +21,7 @@ import snownee.fruits.FFRegistries;
 import snownee.fruits.Hooks;
 import snownee.fruits.gadget.GadgetModule;
 import snownee.fruits.gadget.ScentType;
+import snownee.fruits.util.CommonProxy;
 
 @Mixin(value = LivingEntity.class, priority = 600)
 public abstract class LivingEntityMixin extends Entity {
@@ -32,7 +31,11 @@ public abstract class LivingEntityMixin extends Entity {
 
 	@Inject(method = "randomTeleport", at = @At("HEAD"), cancellable = true)
 	private void randomTeleport(double x, double y, double z, boolean broadcastTeleport, CallbackInfoReturnable<Boolean> cir) {
-		if (Hooks.gadget && GadgetModule.ENDER.get().isActiveAt(Objects.requireNonNull(level()).getChunkAt(blockPosition()))) {
+		if (!Hooks.gadget) {
+			return;
+		}
+		LevelChunk chunk = CommonProxy.getLoadedChunkAt(level(), blockPosition());
+		if (chunk != null && GadgetModule.ENDER.get().isActiveAt(chunk)) {
 			cir.setReturnValue(false);
 		}
 	}
@@ -61,8 +64,8 @@ public abstract class LivingEntityMixin extends Entity {
 		if (level().isClientSide() || !Hooks.gadget) {
 			return;
 		}
-		LevelChunk chunk = level().getChunkAt(blockPosition());
-		if (chunk.isEmpty()) {
+		LevelChunk chunk = CommonProxy.getLoadedChunkAt(level(), blockPosition());
+		if (chunk == null || chunk.isEmpty()) {
 			return;
 		}
 		for (ScentType type : FFRegistries.SCENT_TYPE) {

--- a/src/main/java/snownee/fruits/util/CommonProxy.java
+++ b/src/main/java/snownee/fruits/util/CommonProxy.java
@@ -38,6 +38,7 @@ import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.SectionPos;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.data.worldgen.features.VegetationFeatures;
 import net.minecraft.data.worldgen.placement.PlacementUtils;
@@ -74,6 +75,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.EmptyLevelChunk;
+import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.world.level.levelgen.GenerationStep;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
@@ -220,6 +222,20 @@ public class CommonProxy implements ModInitializer {
 	public static boolean isBeehive(ItemStack itemStack) {
 		return itemStack.is(Items.BEEHIVE) || itemStack.is(Items.BEE_NEST) || Block.byItem(itemStack.getItem()).defaultBlockState().is(
 				BlockTags.BEEHIVES);
+	}
+
+	/**
+	 * Unlike {@link Level#getChunkAt(BlockPos)}, never schedules or waits for a chunk load. Also null off-thread.
+	 * <p>
+	 * Do not "fix" a null return by loading the chunk: scent lives in a chunk attachment, so an unloaded chunk cannot
+	 * hold an active scent and loading cannot change the answer. It can only re-enter the chunk system from entity
+	 * unload, where vanilla dismounts and repositions passengers while the section manager iterates pending unloads.
+	 */
+	@Nullable
+	public static LevelChunk getLoadedChunkAt(Level level, BlockPos pos) {
+		return level.getChunkSource().getChunkNow(
+				SectionPos.blockToSectionCoord(pos.getX()),
+				SectionPos.blockToSectionCoord(pos.getZ()));
 	}
 
 	public static void setScentTime(ChunkAccess chunk, ScentType type, long time) {


### PR DESCRIPTION
## Problem

The scent checks resolve chunks with `Level#getChunkAt`, which is `getChunk(x, z, FULL, load = true)` — a **blocking** load.

Vanilla reaches `Entity#teleportTo` from inside the entity-section unload loop:

```
ServerEntityManager.unloadChunks() / flush()
  -> pendingUnloads.removeIf(...)
   -> unload(long) -> trySave -> unload(EntityLike)
    -> Entity.setRemoved(...)
     -> getPassengers().forEach(Entity::stopRiding)   <- unconditional
      -> LivingEntity.stopRiding -> onDismounted -> dismountTo -> teleportTo
       -> scent mixin -> getChunkAt -> ServerChunkCache.getChunk(FULL, load = true)
```

So the scent system re-enters the chunk system while `ServerEntityManager` is mid-iteration over `pendingUnloads`. On a 12-player 1.20.1 server this produced two crashes about 60 seconds apart:

1. `java.lang.ArrayIndexOutOfBoundsException: Index 39 out of bounds for length 33` in `LongOpenHashSet$SetIterator.shiftKeys`, when the re-entrant load mutated the very `LongSet` being iterated and the backing table was rehashed to a smaller capacity mid-`removeIf`.
2. `java.lang.Error: Watchdog` — 60 s tick timeout with the server thread parked in `getChunk` during `flush()` at shutdown.

Both are reproducible, see below.

## Fix

New `CommonProxy#getLoadedChunkAt(Level, BlockPos)` resolving through `ChunkSource#getChunkNow`, which never schedules or waits for a load. Six call sites converted, treating `null` as *"no scent here"*.

This is safe by construction: scent lives in a **chunk attachment**, so an unloaded chunk cannot hold an active scent — loading could never change the answer, it could only re-enter the chunk system. `null` falls through to vanilla behaviour at every site, so no check becomes more restrictive than before.

It also matches the idiom already used in `ScentedCandleBlockEntity#getChunksAtExactChessboardDistance`, which uses `getChunk(..., FULL, false)` with a null filter.

| Site | Behaviour on `null` |
| --- | --- |
| `scent/EntityMixin#teleportTo` | don't cancel — vanilla teleports |
| `scent/LivingEntityMixin#randomTeleport` | don't suppress |
| `scent/LivingEntityMixin#tick` | early return (keeps the existing `isEmpty()` check) |
| `scent/EndermanTakeBlockGoalMixin#canPlaceBlock` | treat as inactive |
| `scent/EndermanLeaveBlockGoalMixin` (`@WrapOperation`) | always `original.call(...)`, never null |
| `bee/network/CInspectTargetPacket` | report no scents |

Side benefit: `scent/LivingEntityMixin#tick` runs for every `LivingEntity` every tick and now performs a cache lookup instead of a full `getChunk` call.

`ScentCommand` is deliberately **not** changed — commands cannot execute inside the unload loop, and an operator running `/fruitfulfun scent` has explicitly asked for that chunk.

The second commit is separable: `CInspectTargetPacket` resolved the scent chunk from a position taken straight off the wire, letting a client trigger arbitrary chunk loads on the server.

## Verification

Reproduced and fixed on a headless Fabric 1.20.1 dedicated server (Fabric API 0.92.11, Kiwi 11.10.3, Lychee 5.1.24) with an instrumentation mod that logs any `ServerChunkCache#getChunk(load = true)` for a **non-resident** chunk with a `fruitfulfun` frame on the stack. Scenario: a mounted pig + husk pair in a force-loaded chunk, then dropping the forceload and stopping the server.

| | stock `7.9.0` | patched |
| --- | --- | --- |
| Blocking chunk loads from scent code | **4** (one run capped at **100+**) | **0** |
| Ender scent still suppresses enderman teleport | — | **yes** — `Pos` byte-identical across 20 damage events, with `fruitfulfun:ender - 187t` confirmed active first |
| Server load | — | clean, no mixin errors |
| Shutdown | hung, reproducing the watchdog crash | exits cleanly |

The captured stack matches the production crash frame-for-frame, including `class_5579.java:392/394/316/300/319/333`, `class_1297.java:3635/2934`, `class_1309.java:2860/2040` and the mixin handler at `class_1297.java:3828`.

The enderman assertion is the regression guard: a patch that simply returned early would show zero blocking loads while silently disabling the feature. It is gated behind a positive control that fails unless scent is confirmed active first, so it cannot pass vacuously.

## Notes

- Behaviour is unchanged whenever the chunk is resident, which is every case where the feature was actually observable.
- `getChunkNow` also returns `null` off-thread, which makes the failure mode safe rather than blocking.
- Branches cleanly off `1.20.1-fabric` @ `e7b5f96` — no rebase needed.
- Not addressed here: `CInspectTargetPacket` still performs no distance validation on the client-supplied position. Happy to add that if you'd like it in the same PR.
- The same pattern exists on other branches (`26.1-fabric` etc.); I've only touched `1.20.1-fabric`. Glad to port it if useful.
